### PR TITLE
Assemblies

### DIFF
--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import time
 from paperless.local import LocalStorage, DEFAULT_IMPLEMENTATION
 from paperless.objects.orders import Order, Operation
 
@@ -17,6 +18,8 @@ class TestLocalStorage(unittest.TestCase):
         self.assertIsNone(storage.get_last_processed(Order))
         storage.process(Order, 1, True)
         self.assertEqual(1, storage.get_last_processed(Order))
+        # last processed is by timestamp, so they need to be 1 sec apart
+        time.sleep(1.1)
         storage.process(Order, 2, True)
         self.assertEqual(2, storage.get_last_processed(Order))
         storage.process(Operation, 10, True)

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -100,3 +100,22 @@ class TestOrders(unittest.TestCase):
         self.assertIn('has been charged', summ)
         summ = so3.summary(dt, 'purchase_order')
         self.assertIn('bill customer', summ)
+
+    def test_assemblies(self):
+        self.client.get_resource = MagicMock(return_value=self.mock_order_json)
+        o = Order.get(1)
+        oi = o.order_items[0]
+        assm = list(oi.iterate_assembly())
+        self.assertEqual(8, len(assm))
+        self.assertTrue(assm[0].component.is_root_component)
+        self.assertEqual(0, assm[0].level)
+        expected_order = [
+            32053,
+            32059, 32058, 32060,
+            32057, 32056, 32055, 32054
+        ]
+        self.assertEqual(
+            expected_order,
+            [c.component.id for c in assm]
+        )
+        self.assertEqual(2, assm[4].level)

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -119,3 +119,4 @@ class TestOrders(unittest.TestCase):
             [c.component.id for c in assm]
         )
         self.assertEqual(2, assm[4].level)
+        self.assertEqual(4, assm[4].level_count)

--- a/tests/unit/test_quotes.py
+++ b/tests/unit/test_quotes.py
@@ -69,6 +69,3 @@ class TestQuotes(unittest.TestCase):
         # test parent supplier order
         parent_supplier_order = q.parent_supplier_order
         self.assertEqual(parent_supplier_order.number, 16)
-
-
-


### PR DESCRIPTION
This introduces a method on OrderItem that traverses the assembly tree, yielding instances of a new "AssemblyComponent" class, which contains the component along with necessary tree metadata.