### PR TITLE
Add salesperson to contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ A contact represents an individual at an account. A contact has the following fi
     * notes: string
     * phone: string
     * phone_ext: string
+    * salesperson: Salesperson(optional)
 
 ###Importing the Contact class
 
@@ -373,6 +374,16 @@ This will update the contact in Paperless Parts and refresh the local instance
     contact.create()
 ```
 
+### Adding a salesperson to a Contact
+```python
+    from paperless.objects.common import Salesperson
+    salesperson = Salesperson(email="sales@paperlessparts.com")
+    contact.salesperson = salesperson
+    contact.update()
+```
+This will update the contact in Paperless Parts and refresh the local instance
+
+
 ##Accounts
 An account represents a company. An account has the following fields:
 
@@ -387,6 +398,7 @@ An account represents a company. An account has the following fields:
     * payment_terms: string(optional)
     * payment_terms_period: int(optional)
     * purchase_orders_enabled: boolean(optional)
+    * salesperson: Salesperson(optional)
     * sold_to_address: Address object(optional)
     * tax_exempt: boolean(optional)
     * tax_rate: float(optional)
@@ -498,9 +510,10 @@ A facility represents a location for a company. A facility has the following fie
     * account_id: int
     * address: Address object(optional)
     * attention: string(optional)
-    * name: string
     * created: string(optional)
     * id: int
+    * name: string
+    * salesperson: Salesperson(optional)
 
 ###Importing the Facility class
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,9 @@ This will update the contact in Paperless Parts and refresh the local instance
     contact.salesperson = salesperson
     contact.update()
 ```
-This will update the contact in Paperless Parts and refresh the local instance
+This will update the contact in Paperless Parts and refresh the local instance.
+
+Note: A salespersons email must correspond to a group member for the user group whose API-Token is being used. If another email is used, the request will return an HTTP 400 Error with a relevant error message.
 
 
 ##Accounts

--- a/paperless/api_mappers/common.py
+++ b/paperless/api_mappers/common.py
@@ -1,0 +1,10 @@
+from paperless.api_mappers import BaseMapper
+
+class SalespersonMapper(BaseMapper):
+    @classmethod
+    def map(cls, resource):
+        mapped_result = {}
+        field_keys = ['first_name', 'last_name', 'email']
+        for key in field_keys:
+            mapped_result[key] = resource.get(key, None)
+        return mapped_result

--- a/paperless/api_mappers/customers.py
+++ b/paperless/api_mappers/customers.py
@@ -2,6 +2,8 @@ from paperless.api_mappers import (
     BaseMapper,
 )
 
+from .common import SalespersonMapper
+
 
 class AccountMapper(BaseMapper):
     @classmethod
@@ -36,6 +38,11 @@ class AccountMapper(BaseMapper):
         )
         mapped_result['billing_addresses'] = map(
             BillingAddressMapper.map, resource['billing_addresses']
+        )
+        mapped_result['salesperson'] = (
+            SalespersonMapper.map(resource['salesperson'])
+            if resource['salesperson']
+            else None
         )
         return mapped_result
 
@@ -139,6 +146,11 @@ class ContactMapper(BaseMapper):
         mapped_result['address'] = (
             AddressMapper.map(resource['address']) if resource['address'] else None
         )
+        mapped_result['salesperson'] = (
+            SalespersonMapper.map(resource['salesperson'])
+            if resource['salesperson']
+            else None
+        )
         return mapped_result
 
 
@@ -151,6 +163,11 @@ class FacilityMapper(BaseMapper):
             mapped_result[key] = resource.get(key, None)
         mapped_result['address'] = (
             AddressMapper.map(resource['address']) if resource['address'] else None
+        )
+        mapped_result['salesperson'] = (
+            SalespersonMapper.map(resource['salesperson'])
+            if resource['salesperson']
+            else None
         )
         return mapped_result
 

--- a/paperless/api_mappers/orders.py
+++ b/paperless/api_mappers/orders.py
@@ -4,7 +4,7 @@ from paperless.api_mappers.components import (
     OperationQuantityMapper,
     ProcessMapper,
 )
-from paperless.api_mappers.quotes import QuoteSalesPersonMapper
+from .common import SalespersonMapper
 
 
 class AddOnMapper(BaseMapper):
@@ -215,12 +215,17 @@ class OrderDetailsMapper(BaseMapper):
         mapped_result['contact'] = OrderContactMapper.map(resource['contact'])
         mapped_result['customer'] = OrderCustomerMapper.map(resource['customer'])
         mapped_result['sales_person'] = (
-            QuoteSalesPersonMapper.map(resource['sales_person'])
+            SalespersonMapper.map(resource['sales_person'])
             if resource['sales_person']
             else None
         )
+        mapped_result['salesperson'] = (
+            SalespersonMapper.map(resource['salesperson'])
+            if resource['salesperson']
+            else None
+        )
         mapped_result['estimator'] = (
-            QuoteSalesPersonMapper.map(resource['estimator'])
+            SalespersonMapper.map(resource['estimator'])
             if resource['estimator']
             else None
         )

--- a/paperless/api_mappers/quotes.py
+++ b/paperless/api_mappers/quotes.py
@@ -5,6 +5,8 @@ from paperless.api_mappers.components import (
     ProcessMapper,
 )
 
+from .common import SalespersonMapper
+
 
 class QuoteMetricsMapper(BaseMapper):
     @classmethod
@@ -65,16 +67,6 @@ class QuoteContactMapper(BaseMapper):
             QuoteAccountMapper.map(resource['account']) if resource['account'] else None
         )
         field_keys = ['id', 'email', 'first_name', 'last_name', 'notes']
-        for key in field_keys:
-            mapped_result[key] = resource.get(key, None)
-        return mapped_result
-
-
-class QuoteSalesPersonMapper(BaseMapper):
-    @classmethod
-    def map(cls, resource):
-        mapped_result = {}
-        field_keys = ['first_name', 'last_name', 'email']
         for key in field_keys:
             mapped_result[key] = resource.get(key, None)
         return mapped_result
@@ -314,12 +306,17 @@ class QuoteDetailsMapper(BaseMapper):
             else None
         )
         mapped_result['sales_person'] = (
-            QuoteSalesPersonMapper.map(resource['sales_person'])
+            SalespersonMapper.map(resource['sales_person'])
             if resource['sales_person']
             else None
         )
+        mapped_result['salesperson'] = (
+            SalespersonMapper.map(resource['salesperson'])
+            if resource['salesperson']
+            else None
+        )
         mapped_result['estimator'] = (
-            QuoteSalesPersonMapper.map(resource['estimator'])
+            SalespersonMapper.map(resource['estimator'])
             if resource['estimator']
             else None
         )

--- a/paperless/json_encoders/common.py
+++ b/paperless/json_encoders/common.py
@@ -5,10 +5,10 @@ from paperless.json_encoders import BaseJSONEncoder
 class SalespersonEncoder(BaseJSONEncoder):
     @classmethod
     def encode(cls, resource, json_dumps=True):
-        if getattr(resource, 'email', False):
-            data = { 'email': getattr(resource, 'email') }
-        else:
-            data = None
+        data = {}
+        field_keys = ['email']
+        for key in field_keys:
+            data[key] = getattr(resource, key, None)
 
         if json_dumps:
             return json.dumps(data)

--- a/paperless/json_encoders/common.py
+++ b/paperless/json_encoders/common.py
@@ -1,0 +1,16 @@
+import json
+
+from paperless.json_encoders import BaseJSONEncoder
+
+class SalespersonEncoder(BaseJSONEncoder):
+    @classmethod
+    def encode(cls, resource, json_dumps=True):
+        if getattr(resource, 'email', False):
+            data = { 'email': getattr(resource, 'email') }
+        else:
+            data = None
+
+        if json_dumps:
+            return json.dumps(data)
+        else:
+            return data

--- a/paperless/json_encoders/customers.py
+++ b/paperless/json_encoders/customers.py
@@ -36,6 +36,8 @@ class AccountEncoder(BaseJSONEncoder):
         salesperson = getattr(resource, 'salesperson', None)
         if salesperson is not None and salesperson is not NO_UPDATE:
             data['salesperson'] = SalespersonEncoder.encode(salesperson, json_dumps=False)
+        else:
+            data['salesperson'] = salesperson
 
         sold_to_address = getattr(resource, 'sold_to_address', None)
         if sold_to_address is not None and sold_to_address is not NO_UPDATE:
@@ -120,6 +122,8 @@ class ContactEncoder(BaseJSONEncoder):
         salesperson = getattr(resource, 'salesperson', None)
         if salesperson is not None and salesperson is not NO_UPDATE:
             data['salesperson'] = SalespersonEncoder.encode(salesperson, json_dumps=False)
+        else:
+            data['salesperson'] = salesperson
 
         filtered_data = {}
         for key in data:
@@ -161,6 +165,8 @@ class FacilityEncoder(BaseJSONEncoder):
         salesperson = getattr(resource, 'salesperson', None)
         if salesperson is not None and salesperson is not NO_UPDATE:
             data['salesperson'] = SalespersonEncoder.encode(salesperson, json_dumps=False)
+        else:
+            data['salesperson'] = salesperson
 
         filtered_data = {}
         for key in data:

--- a/paperless/json_encoders/customers.py
+++ b/paperless/json_encoders/customers.py
@@ -2,7 +2,7 @@ import json
 
 from paperless.json_encoders import BaseJSONEncoder
 from paperless.objects.utils import NO_UPDATE
-
+from .common import SalespersonEncoder
 
 class AccountEncoder(BaseJSONEncoder):
     @classmethod
@@ -32,6 +32,10 @@ class AccountEncoder(BaseJSONEncoder):
             data['credit_line'] = MoneyEncoder.encode(credit_line, json_dumps=False)
         else:
             data['credit_line'] = credit_line
+
+        salesperson = getattr(resource, 'salesperson', None)
+        if salesperson is not None and salesperson is not NO_UPDATE:
+            data['salesperson'] = SalespersonEncoder.encode(salesperson, json_dumps=False)
 
         sold_to_address = getattr(resource, 'sold_to_address', None)
         if sold_to_address is not None and sold_to_address is not NO_UPDATE:
@@ -113,6 +117,10 @@ class ContactEncoder(BaseJSONEncoder):
         else:
             data['address'] = address
 
+        salesperson = getattr(resource, 'salesperson', None)
+        if salesperson is not None and salesperson is not NO_UPDATE:
+            data['salesperson'] = SalespersonEncoder.encode(salesperson, json_dumps=False)
+
         filtered_data = {}
         for key in data:
             if data[key] is not NO_UPDATE:
@@ -149,6 +157,10 @@ class FacilityEncoder(BaseJSONEncoder):
         address = getattr(resource, 'address', None)
         if address is not None and address is not NO_UPDATE:
             data['address'] = AddressEncoder.encode(address, json_dumps=False)
+
+        salesperson = getattr(resource, 'salesperson', None)
+        if salesperson is not None and salesperson is not NO_UPDATE:
+            data['salesperson'] = SalespersonEncoder.encode(salesperson, json_dumps=False)
 
         filtered_data = {}
         for key in data:

--- a/paperless/objects/common.py
+++ b/paperless/objects/common.py
@@ -40,3 +40,10 @@ class Money:
 
     def __bool__(self):
         return bool(self.dollars)
+
+
+@attr.s(frozen=False)
+class Salesperson:
+    first_name: str = attr.ib(validator=attr.validators.instance_of(str))
+    last_name: str = attr.ib(validator=attr.validators.instance_of(str))
+    email: str = attr.ib(validator=attr.validators.instance_of(str))

--- a/paperless/objects/common.py
+++ b/paperless/objects/common.py
@@ -1,6 +1,7 @@
 import attr
 import decimal
 from decimal import Decimal
+from typing import Optional
 
 from .utils import positive_number_validator
 
@@ -44,6 +45,12 @@ class Money:
 
 @attr.s(frozen=False)
 class Salesperson:
-    first_name: str = attr.ib(validator=attr.validators.instance_of(str))
-    last_name: str = attr.ib(validator=attr.validators.instance_of(str))
     email: str = attr.ib(validator=attr.validators.instance_of(str))
+    first_name: Optional[str] = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    last_name: Optional[str] = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )

--- a/paperless/objects/customers.py
+++ b/paperless/objects/customers.py
@@ -29,7 +29,7 @@ from paperless.mixins import (
 )
 
 from .address import Address
-from .common import Money
+from .common import Money, Salesperson
 from .utils import (
     NO_UPDATE,
     convert_cls,
@@ -182,6 +182,9 @@ class Account(
     purchase_orders_enabled = attr.ib(
         default=NO_UPDATE, validator=attr.validators.instance_of((bool, object))
     )
+    salesperson = attr.ib(
+        default=NO_UPDATE, converter=optional_convert(convert_cls(Salesperson))
+    )
     sold_to_address = attr.ib(
         default=NO_UPDATE, converter=optional_convert(convert_cls(Address))
     )
@@ -331,6 +334,9 @@ class Contact(
         default=NO_UPDATE,
         validator=attr.validators.optional(attr.validators.instance_of((str, object))),
     )
+    salesperson = attr.ib(
+        default=NO_UPDATE, converter=optional_convert(convert_cls(Salesperson))
+    )
 
     @classmethod
     def construct_delete_url(cls):
@@ -432,6 +438,9 @@ class Facility(
     )
     id = attr.ib(
         default=NO_UPDATE, validator=attr.validators.instance_of((int, object))
+    )
+    salesperson = attr.ib(
+        default=NO_UPDATE, converter=optional_convert(convert_cls(Salesperson))
     )
 
     @classmethod

--- a/paperless/objects/orders.py
+++ b/paperless/objects/orders.py
@@ -9,10 +9,9 @@ from paperless.api_mappers.orders import OrderDetailsMapper, OrderMinimumMapper
 from paperless.client import PaperlessClient
 from paperless.mixins import FromJSONMixin, ListMixin, ReadMixin, ToDictMixin
 from paperless.objects.components import BaseOperation
-from paperless.objects.quotes import SalesPerson
 
 from .address import AddressInfo
-from .common import Money
+from .common import Money, Salesperson
 from .components import AssemblyMixin, BaseComponent
 from .utils import convert_cls, convert_iterable, optional_convert
 
@@ -396,7 +395,7 @@ class Order(FromJSONMixin, ListMixin, ReadMixin, ToDictMixin):
     deliver_by: Optional[str] = attr.ib(
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
-    estimator: SalesPerson = attr.ib(converter=convert_cls(SalesPerson))
+    estimator: Salesperson = attr.ib(converter=convert_cls(Salesperson))
     number: int = attr.ib(validator=attr.validators.instance_of(int))
     order_items: List[OrderItem] = attr.ib(converter=convert_iterable(OrderItem))
     payment_details: PaymentDetails = attr.ib(converter=convert_cls(PaymentDetails))
@@ -404,7 +403,8 @@ class Order(FromJSONMixin, ListMixin, ReadMixin, ToDictMixin):
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
     quote_number: int = attr.ib(validator=attr.validators.instance_of(int))
-    sales_person: SalesPerson = attr.ib(converter=convert_cls(SalesPerson))
+    sales_person: Salesperson = attr.ib(converter=convert_cls(Salesperson))
+    salesperson: Salesperson = attr.ib(converter=convert_cls(Salesperson))
     shipments: List[OrderShipment] = attr.ib(converter=convert_iterable(OrderShipment))
     shipping_info: AddressInfo = attr.ib(converter=convert_cls(AddressInfo))
     shipping_option: ShippingOption = attr.ib(converter=convert_cls(ShippingOption))

--- a/paperless/objects/quotes.py
+++ b/paperless/objects/quotes.py
@@ -303,6 +303,7 @@ class Quote(
         validator=attr.validators.optional(attr.validators.instance_of(int))
     )
     sales_person: Salesperson = attr.ib(converter=convert_cls(Salesperson))
+    salesperson: Salesperson = attr.ib(converter=convert_cls(Salesperson))
     estimator: Salesperson = attr.ib(converter=convert_cls(Salesperson))
     contact: Contact = attr.ib(converter=convert_cls(Contact))
     customer: Customer = attr.ib(converter=convert_cls(Customer))

--- a/paperless/objects/quotes.py
+++ b/paperless/objects/quotes.py
@@ -9,7 +9,7 @@ from paperless.client import PaperlessClient
 from paperless.mixins import FromJSONMixin, ListMixin, ToDictMixin
 from paperless.objects.components import BaseOperation
 
-from .common import Money, SalesPerson
+from .common import Money, Salesperson
 from .components import AssemblyMixin, BaseComponent
 from .utils import (
     convert_cls,
@@ -302,8 +302,8 @@ class Quote(
     revision_number: Optional[int] = attr.ib(
         validator=attr.validators.optional(attr.validators.instance_of(int))
     )
-    sales_person: SalesPerson = attr.ib(converter=convert_cls(SalesPerson))
-    estimator: SalesPerson = attr.ib(converter=convert_cls(SalesPerson))
+    sales_person: Salesperson = attr.ib(converter=convert_cls(Salesperson))
+    estimator: Salesperson = attr.ib(converter=convert_cls(Salesperson))
     contact: Contact = attr.ib(converter=convert_cls(Contact))
     customer: Customer = attr.ib(converter=convert_cls(Customer))
     tax_rate: Optional[Decimal] = attr.ib(

--- a/paperless/objects/quotes.py
+++ b/paperless/objects/quotes.py
@@ -9,7 +9,7 @@ from paperless.client import PaperlessClient
 from paperless.mixins import FromJSONMixin, ListMixin, ToDictMixin
 from paperless.objects.components import BaseOperation
 
-from .common import Money
+from .common import Money, SalesPerson
 from .components import AssemblyMixin, BaseComponent
 from .utils import (
     convert_cls,
@@ -155,13 +155,6 @@ class QuoteComponent(BaseComponent):
         converter=convert_iterable(QuoteOperation)
     )
     quantities: List[Quantity] = attr.ib(converter=convert_iterable(Quantity))
-
-
-@attr.s(frozen=False)
-class SalesPerson:
-    first_name: str = attr.ib(validator=attr.validators.instance_of(str))
-    last_name: str = attr.ib(validator=attr.validators.instance_of(str))
-    email: str = attr.ib(validator=attr.validators.instance_of(str))
 
 
 @attr.s(frozen=False)

--- a/tests/unit/mock_data/account.json
+++ b/tests/unit/mock_data/account.json
@@ -21,6 +21,11 @@
   "phone": "6035555555",
   "phone_ext": null,
   "purchase_orders_enabled": true,
+  "salesperson": {
+    "first_name": "William",
+    "last_name": "Headrick",
+    "email": "william+stack_pusher@paperlessparts.com"
+  },
   "sold_to_address": {
     "id": 1,
     "address1": "1 City Hall Sq.",

--- a/tests/unit/mock_data/contact.json
+++ b/tests/unit/mock_data/contact.json
@@ -16,5 +16,10 @@
   "last_name": "Smith",
   "notes": "test notes",
   "phone": "6035555555",
-  "phone_ext": ""
+  "phone_ext": "",
+  "salesperson": {
+    "first_name": "William",
+    "last_name": "Headrick",
+    "email": "william+stack_pusher@paperlessparts.com"
+  }
 }

--- a/tests/unit/mock_data/facility.json
+++ b/tests/unit/mock_data/facility.json
@@ -11,5 +11,10 @@
   },
   "attention": "John Smith",
   "id": 1,
-  "name": "Boston Office"
+  "name": "Boston Office",
+  "salesperson": {
+    "first_name": "William",
+    "last_name": "Headrick",
+    "email": "william+stack_pusher@paperlessparts.com"
+  }
 }

--- a/tests/unit/mock_data/minimal_order.json
+++ b/tests/unit/mock_data/minimal_order.json
@@ -4039,6 +4039,11 @@
     "last_name": "Carrington",
     "email": "rob.carrington@paperlessparts.com"
   },
+  "salesperson": {
+    "first_name": "Rob",
+    "last_name": "Carrington",
+    "email": "rob.carrington@paperlessparts.com"
+  },
   "shipments": [],
   "shipping_info": null,
   "shipping_option": null,

--- a/tests/unit/test_contacts.py
+++ b/tests/unit/test_contacts.py
@@ -52,6 +52,9 @@ class TestContact(unittest.TestCase):
                 "postal_code": "02114-1702",
                 "state": "MA"
             },
+            "salesperson": {
+                "email": "william+stack_pusher@paperlessparts.com"
+            }
         }
         self.assertEqual(c.to_json(), json.dumps(expected_contact_json))
 
@@ -132,6 +135,9 @@ class TestAccount(unittest.TestCase):
             "tax_rate": None,
             "url": "https://www.paperlessparts.com",
             "purchase_orders_enabled": True,
+            "salesperson": {
+                "email": "william+stack_pusher@paperlessparts.com"
+            },
             "sold_to_address": {
                 "address1": "1 City Hall Sq.",
                 "address2": None,
@@ -225,6 +231,9 @@ class TestFacility(unittest.TestCase):
                 "country": "USA",
                 "postal_code": "02114",
                 "state": "MA",
+            },
+            "salesperson": {
+                "email": "william+stack_pusher@paperlessparts.com"
             }
         }
         self.assertEqual(f.to_json(), json.dumps(expected_facility_json))


### PR DESCRIPTION
This Pull Request:

1. Adds a common salesperson object to represent salepersons for Quotes, Orders, Accounts, Contacts, and Facilities
2. Adds a SalespersonEncoder which will serialize an email address used to identify salespersons
3. Adds a SalespersonMapper
4. Adds salesperson to quotes and orders
5. Adds an example of how to use the sdk to assign a salesperson to a Contact