### PR TITLE
Quote order erp codes

### DIFF
--- a/paperless/api_mappers/quotes.py
+++ b/paperless/api_mappers/quotes.py
@@ -141,6 +141,7 @@ class QuoteDetailsMapper(BaseMapper):
             'sales_person',
             'contact',
             'customer',
+            'erp_code',
         ]
         for key in field_keys:
             mapped_result[key] = resource.get(key, None)

--- a/paperless/client.py
+++ b/paperless/client.py
@@ -162,16 +162,15 @@ class PaperlessClient(object):
         resp = self.request(url=resource_url, method=self.METHODS.POST, data=data)
         return resp.json()
 
-    def update_resource(self, resource_url, id, data):
+    def update_resource(self, resource_url, id, data, params=None):
         """
-            takes a resource type
-            performs GET request for last updated + 1
-            will return true if the next object exists, else false
         """
-
         req_url = '{}/{}'.format(resource_url, id)
+        if params is not None:
+            resp = self.request(url=req_url, method=self.METHODS.PATCH, data=data, params=params)
+        else:
+            resp = self.request(url=req_url, method=self.METHODS.PATCH, data=data)
 
-        resp = self.request(url=req_url, method=self.METHODS.PATCH, data=data)
         return resp.json()
 
     def delete_resource(self, resource_url, id):

--- a/paperless/json_encoders/orders.py
+++ b/paperless/json_encoders/orders.py
@@ -1,0 +1,7 @@
+from paperless.json_encoders import SmartJSONEncoder
+
+
+class OrderEncoder(SmartJSONEncoder):
+    basic_field_keys = [
+        'erp_code'
+    ]

--- a/paperless/json_encoders/quotes.py
+++ b/paperless/json_encoders/quotes.py
@@ -1,0 +1,7 @@
+from paperless.json_encoders import SmartJSONEncoder
+
+
+class QuoteEncoder(SmartJSONEncoder):
+    basic_field_keys = [
+        'erp_code'
+    ]

--- a/paperless/mixins.py
+++ b/paperless/mixins.py
@@ -239,10 +239,13 @@ class UpdateMixin(object):
             self.construct_patch_url(), primary_key, data=data
         )
         resp_obj = self.from_json(resp)
+        # This filter is designed to remove methods, properties, and private data members and only let through the
+        # fields explicitly defined in the class definition
         keys = filter(
             lambda x: not x.startswith('__')
             and not x.startswith('_')
-            and type(getattr(resp_obj, x)) != types.MethodType,
+            and type(getattr(resp_obj, x)) != types.MethodType
+            and (not isinstance(getattr(resp_obj.__class__, x), property) if x in dir(resp_obj.__class__) else True),
             dir(resp_obj),
         )
         for key in keys:

--- a/paperless/objects/quotes.py
+++ b/paperless/objects/quotes.py
@@ -443,10 +443,13 @@ class Quote(
             self.construct_patch_url(), primary_key, data=data, params=params
         )
         resp_obj = self.from_json(resp)
+        # This filter is designed to remove methods, properties, and private data members and only let through the
+        # fields explicitly defined in the class definition
         keys = filter(
             lambda x: not x.startswith('__')
-                      and not x.startswith('_')
-                      and type(getattr(resp_obj, x)) != MethodType,
+            and not x.startswith('_')
+            and type(getattr(resp_obj, x)) != MethodType
+            and (not isinstance(getattr(resp_obj.__class__, x), property) if x in dir(resp_obj.__class__) else True),
             dir(resp_obj),
         )
         for key in keys:


### PR DESCRIPTION
Add the erp_code field to the Quote and Order objects. Also, add the ability to PATCH select fields for Quotes and Orders. At the moment, the only field you can PATCH is `erp_code`, but once the API allows additional fields, it is a simple matter of adding those fields to the QuoteEncoder and OrderEncoder, which dictate the subset of fields that get serialized in the PATCH body.

I had to make minor modifications to the PaperlessClient to support updating quotes (since quotes are uniquely identified by the combination of their number, supplied in the url, and their revision, supplied in the query params) and to the UpdateMixin, to support the helper properties on the Order object.