### PR TITLE
Add new fields to Quote object: uuid, order_numbers, metadata

### DIFF
--- a/paperless/api_mappers/quotes.py
+++ b/paperless/api_mappers/quotes.py
@@ -191,10 +191,18 @@ class QuoteDetailsMapper(BaseMapper):
             'customer',
             'erp_code',
             'send_from_facility',
-            'rfq_number'
+            'rfq_number',
+            'uuid',
+            'order_numbers',
+            'metadata'
         ]
         for key in field_keys:
             mapped_result[key] = resource.get(key, None)
+        
+        # Handle special default values for new fields
+        if 'order_numbers' not in resource or resource['order_numbers'] is None:
+            mapped_result['order_numbers'] = []
+            
         bool_keys = ['export_controlled', 'is_unviewed_drafted_rfq']
         for key in bool_keys:
             mapped_result[key] = resource.get(key, False)

--- a/paperless/objects/quotes.py
+++ b/paperless/objects/quotes.py
@@ -522,6 +522,18 @@ class Quote(
             attr.validators.instance_of((int, float, object))
         ),
     )
+    uuid: Optional[str] = attr.ib(
+        validator=attr.validators.optional(attr.validators.instance_of(str)),
+        default=None
+    )
+    order_numbers: List[str] = attr.ib(
+        converter=optional_convert(convert_iterable(str)),
+        default=attr.Factory(list)
+    )
+    metadata: Optional[Dict[str, Union[str, int, float, bool]]] = attr.ib(
+        validator=attr.validators.optional(attr.validators.instance_of(dict)),
+        default=None
+    )
 
     @classmethod
     def construct_get_url(cls):


### PR DESCRIPTION
- Added uuid field (Optional[str]) to Quote class
- Added order_numbers field (List[str]) to Quote class
- Added metadata field (Optional[Dict]) to Quote class
- Updated QuoteDetailsMapper to handle new fields
- Added special handling for order_numbers default value
- Maintains backward compatibility with existing code